### PR TITLE
Added base task class. monkey patch is only applied if a new setting is set. refs #17

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -242,6 +242,9 @@ Set this variable in your settings.py file:
 
     DJANGO_CELERY_FULLDBRESULT_SCHEDULE_ETA = True
 
+    # If you do not want to change your code, set this variable too:
+    DJANGO_CELERY_FULLDBRESULT_MONKEY_PATCH_ASYNC = True
+
 Then create a periodic task in the Django admin or within your code. For
 example:
 
@@ -256,6 +259,24 @@ automatically intercept the task. For example:
 ::
 
     my_task.apply_async(args=[...], kwargs={...}, eta=some_date)
+
+
+Using a Base Task
+~~~~~~~~~~~~~~~~~
+
+When ``DJANGO_CELERY_FULLDBRESULT_MONKEY_PATCH_ASYNC`` is set to True, the
+Task.apply_async is monkey patched to correctly handle scheduled tasks.
+
+This will usually work if you correctly use the ``@shared_task`` or
+``@app.task`` decorators. It will probably fail if you use the legacy ``@task``
+decorator though.
+
+If you encounter any problem with the monkey patching, simply set
+``DJANGO_CELERY_FULLDBRESULT_MONKEY_PATCH_ASYNC`` to False and instead, use a
+base task:
+
+
+::
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -278,6 +278,13 @@ base task:
 
 ::
 
+    from celery import shared_task
+    from django_celery_fulldbresult.tasks import ScheduledTask
+
+    @shared_task(base=ScheduledTask)
+    def do_something(param):
+        print("DOING SOMETHING")
+        return (param, "test")
 
 
 Semantics

--- a/django_celery_fulldbresult/tasks.py
+++ b/django_celery_fulldbresult/tasks.py
@@ -1,11 +1,26 @@
 import json
 from uuid import uuid4
 
-from celery import shared_task, current_app
+from celery import shared_task, current_app, Task
 
 from django.utils.timezone import now
+
+from django_celery_fulldbresult.errors import SchedulingStopPublishing
 from django_celery_fulldbresult.models import (
     TaskResultMeta, SCHEDULED, SCHEDULED_SENT)
+
+
+class ScheduledTask(Task):
+
+    abstract = True
+
+    def apply_async(self, *args, **kwargs):
+        try:
+            return super(ScheduledTask, self).apply_async(*args, **kwargs)
+        except SchedulingStopPublishing as exc:
+            # There was an ETA and the task was not sent to the broker.
+            # A scheduled task was created instead.
+            return self.AsyncResult(exc.task_id)
 
 
 @shared_task(ignore_result=True)

--- a/test_project/test_app/tasks.py
+++ b/test_project/test_app/tasks.py
@@ -1,7 +1,15 @@
 from celery import shared_task
 
+from django_celery_fulldbresult.tasks import ScheduledTask
+
 
 @shared_task
 def do_something(param):
+    print("DOING SOMETHING")
+    return (param, "test")
+
+
+@shared_task(base=ScheduledTask)
+def do_something_alt(param):
     print("DOING SOMETHING")
     return (param, "test")

--- a/test_project/test_app/tests.py
+++ b/test_project/test_app/tests.py
@@ -7,11 +7,13 @@ from celery.states import PENDING
 from django.core.management import call_command
 from django.test import TransactionTestCase
 
+from django_celery_fulldbresult import (
+    apply_async_monkey_patch, unapply_async_monkey_patch)
 from django_celery_fulldbresult.models import (
     TaskResultMeta, SCHEDULED, SCHEDULED_SENT)
 from django_celery_fulldbresult.tasks import send_scheduled_task
 
-from test_app.tasks import do_something
+from test_app.tasks import do_something, do_something_alt
 
 # Create your tests here.
 
@@ -63,7 +65,10 @@ class SignalTest(TransactionTestCase):
             self.assertEqual(0, TaskResultMeta.objects.count())
 
     def test_parameters_schedule_eta(self):
-        with self.settings(DJANGO_CELERY_FULLDBRESULT_SCHEDULE_ETA=True):
+        with self.settings(
+                DJANGO_CELERY_FULLDBRESULT_SCHEDULE_ETA=True,
+                DJANGO_CELERY_FULLDBRESULT_MONKEY_PATCH_ASYNC=True):
+            apply_async_monkey_patch()
             a_date = datetime(2080, 1, 1, tzinfo=utc)
             do_something.apply_async(
                 kwargs={"param": "testing"}, eta=a_date)
@@ -83,10 +88,13 @@ class SignalTest(TransactionTestCase):
 
             kwargs = json.loads(task.kwargs)
             self.assertEqual(kwargs, {"param": "testing"})
+            unapply_async_monkey_patch()
 
     def test_parameters_schedule_eta_ignore_result(self):
         with self.settings(DJANGO_CELERY_FULLDBRESULT_SCHEDULE_ETA=True,
-                           CELERY_IGNORE_RESULT=True):
+                           CELERY_IGNORE_RESULT=True,
+                           DJANGO_CELERY_FULLDBRESULT_MONKEY_PATCH_ASYNC=True):
+            apply_async_monkey_patch()
             a_date = datetime(2080, 1, 1, tzinfo=utc)
             do_something.apply_async(
                 kwargs={"param": "testing"}, eta=a_date)
@@ -106,18 +114,56 @@ class SignalTest(TransactionTestCase):
 
             kwargs = json.loads(task.kwargs)
             self.assertEqual(kwargs, {"param": "testing"})
+            unapply_async_monkey_patch()
 
 
 class SchedulingTest(TransactionTestCase):
 
     def test_parameters_schedule_eta(self):
-        with self.settings(DJANGO_CELERY_FULLDBRESULT_SCHEDULE_ETA=True):
+        with self.settings(
+                DJANGO_CELERY_FULLDBRESULT_SCHEDULE_ETA=True,
+                DJANGO_CELERY_FULLDBRESULT_MONKEY_PATCH_ASYNC=True):
+            apply_async_monkey_patch()
             a_date = datetime(1990, 1, 1, tzinfo=utc)
             do_something.apply_async(
                 kwargs={"param": "testing"}, eta=a_date)
             task = TaskResultMeta.objects.order_by("pk")[0]
             self.assertEqual(
                 "test_app.tasks.do_something",
+                task.task)
+            self.assertEqual(SCHEDULED, task.status)
+
+            send_scheduled_task()
+
+            task = TaskResultMeta.objects.order_by("pk")[0]
+            new_task = TaskResultMeta.objects.order_by("pk")[1]
+
+            # Old task has been marked as sent
+            self.assertEqual(SCHEDULED_SENT, task.status)
+
+            # Old task has a scheduling id
+            self.assertIsNotNone(task.scheduled_id)
+
+            # New task is pending (sent for execution)
+            self.assertEqual(PENDING, new_task.status)
+
+            # No ETA on the new task
+            self.assertIsNone(new_task.eta)
+
+            # The task is of the new task is in the result of the scheduled
+            # task for traceability.
+            self.assertEqual(task.result["new_task_id"], new_task.task_id)
+            unapply_async_monkey_patch()
+
+    def test_parameters_schedule_eta_base_task_class(self):
+        with self.settings(
+                DJANGO_CELERY_FULLDBRESULT_SCHEDULE_ETA=True):
+            a_date = datetime(1990, 1, 1, tzinfo=utc)
+            do_something_alt.apply_async(
+                kwargs={"param": "testing"}, eta=a_date)
+            task = TaskResultMeta.objects.order_by("pk")[0]
+            self.assertEqual(
+                "test_app.tasks.do_something_alt",
                 task.task)
             self.assertEqual(SCHEDULED, task.status)
 
@@ -162,7 +208,10 @@ class ManagerTest(TransactionTestCase):
                 acceptable_states=[PENDING])))
 
     def test_get_stale_scheduled_tasks(self):
-        with self.settings(DJANGO_CELERY_FULLDBRESULT_SCHEDULE_ETA=True):
+        with self.settings(
+                DJANGO_CELERY_FULLDBRESULT_SCHEDULE_ETA=True,
+                DJANGO_CELERY_FULLDBRESULT_MONKEY_PATCH_ASYNC=True):
+            apply_async_monkey_patch()
             a_date = datetime(1990, 1, 1, tzinfo=utc)
             do_something.apply_async(
                 kwargs={"param": "testing"}, eta=a_date)
@@ -178,6 +227,7 @@ class ManagerTest(TransactionTestCase):
                 0,
                 len(TaskResultMeta.objects.get_stale_scheduled_tasks(
                     timedelta(days=365*100))))
+            unapply_async_monkey_patch()
 
 
 class ResultTest(TransactionTestCase):


### PR DESCRIPTION
This was discussed in #17 : essentially we do not want to always monkey patch Task.apply_async. I added a new setting to control the monkey patch.

I also added an abstract Task class that can be used as a [base Task class](http://docs.celeryproject.org/en/latest/userguide/tasks.html#abstract-classes) (this completely replaces the monkey patch).

Note that monkey patching is still interesting because the user does not need to modify existing tasks to use the scheduling feature.
