### PR TITLE
Issue 20 fix djcelery admin defaults

### DIFF
--- a/django_celery_fulldbresult/admin.py
+++ b/django_celery_fulldbresult/admin.py
@@ -49,7 +49,7 @@ trigger_periodic_task.short_description = _("Trigger Periodic Tasks")
 
 
 class CustomPeriodicTaskAdmin(PeriodicTaskAdmin):
-    actions = [trigger_periodic_task, ]
+    actions = PeriodicTaskAdmin.actions + [trigger_periodic_task]
     # XXX djcelery places the enabled flag first, which makes it a icon link.
     # This is ugly and hurts usability so we changed the list display order.
     list_display = ("__unicode__", "enabled", "task", "args", "kwargs")

--- a/django_celery_fulldbresult/admin.py
+++ b/django_celery_fulldbresult/admin.py
@@ -50,7 +50,11 @@ trigger_periodic_task.short_description = _("Trigger Periodic Tasks")
 
 class CustomPeriodicTaskAdmin(PeriodicTaskAdmin):
     actions = [trigger_periodic_task, ]
-    list_filter = ("task", )
+    # XXX djcelery places the enabled flag first, which makes it a icon link.
+    # This is ugly and hurts usability so we changed the list display order.
+    list_display = ("__unicode__", "enabled", "task", "args", "kwargs")
+    list_filter = ("enabled", "task")
+    search_fields = ("name", "args", "kwargs")
 
 
 if getattr(settings, "DJANGO_CELERY_FULLDBRESULT_OVERRIDE_DJCELERY_ADMIN",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django>=1.8
-celery>=3.1
-django_celery>=3.1.16
+celery>=3.1.15
+django_celery>=3.1.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django>=1.8
-celery>=3.1.15
+celery>=3.1.15,<4.0
 django_celery>=3.1.17


### PR DESCRIPTION
Please note that:

1. I removed the toggle enable state action because djcelery already provides enable/disable actions. I think at some point, we were replacing all actions and these default actions were not shown, which led you to create that enable state toggling action.

2. The "enabled" column is no longer editable. The reason is that we would need to modify Django to call PeriodicTasks.changed(...) every time the enable state changes. This is error-prone and I submitted a fix to djcelery for the default enable/disable actions.

3. Celery 4.0 is out. I believe only djcelery@master (unreleased) supports Celery 4, so I limited our support to Celery 3.