### PR TITLE
Issue 22 fix serialization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog - django-celery-fulldbresult
 ======================================
 
+0.5.3 - December 21st 2016
+--------------------------
+
+- Fixed regression bug: bad plain string conversion to JSON
+- Added a command, ./manage.py fix_json_results to fix badly-formatted
+  strings.
+
 0.5.2 - November 7th 2016
 -------------------------
 

--- a/django_celery_fulldbresult/management/commands/fix_json_results.py
+++ b/django_celery_fulldbresult/management/commands/fix_json_results.py
@@ -1,0 +1,54 @@
+from django.core.management import BaseCommand
+
+from django_celery_fulldbresult import serialization
+from django_celery_fulldbresult.models import TaskResultMeta
+
+
+try:
+    from django.utils.encoding import force_text
+except ImportError:
+    from django.utils.encoding import force_unicode as force_text  # noqa
+
+
+def str_loads(data, content_type="application/json", encoding="utf-8"):
+    """Returns the string instead of trying to convert it.
+    """
+    return data
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        real_loads = serialization.loads
+
+        # We monkeypath loads so that query iteration does not fail.
+        serialization.loads = str_loads
+
+        query = TaskResultMeta.objects.all()
+        count = 0
+        fixed = 0
+
+        print("Inspecting {0} task results".format(query.count()))
+
+        for task_result in query:
+            count += 1
+            result = task_result.result
+            if result is None:
+                continue
+            try:
+                real_loads(result)
+            except TypeError:
+                fixed += 1
+                # The result does not correctly load as json.
+                new_value = force_text(result)
+                # This will call dumps, which will fix badly formatted strings.
+                task_result.result = new_value
+                task_result.save()
+
+            if count % 1000 == 0:
+                print("Inspected {0} task results".format(count))
+
+        if fixed:
+            print("Fixed {0} results".format(fixed))
+        else:
+            print("No result to fix")

--- a/django_celery_fulldbresult/models.py
+++ b/django_celery_fulldbresult/models.py
@@ -10,6 +10,11 @@ try:
 except ImportError:
     from django.utils.encoding import force_unicode as force_text  # noqa
 
+try:
+    StringType = basestring
+except NameError:
+    StringType = str
+
 
 from celery import states
 
@@ -96,7 +101,7 @@ class PickledOrJSONObjectField(PickledObjectField):
                     value = serialization.loads(value)
                     return value
                 except Exception:
-                    if isinstance(value, str):
+                    if isinstance(value, StringType):
                         # Badly formatted JSON!
                         raise
                     else:

--- a/django_celery_fulldbresult/serialization.py
+++ b/django_celery_fulldbresult/serialization.py
@@ -6,6 +6,7 @@ def dumps(data):
     """Serializes data using Kombu serializer.
     """
     try:
+        # dumps will convert any strings into json-compatible strings.
         content_type, encoding, data = k_registry.dumps(
             data, serializer="json")
     except EncodeError as e:

--- a/django_celery_fulldbresult/serialization.py
+++ b/django_celery_fulldbresult/serialization.py
@@ -3,10 +3,11 @@ from kombu.exceptions import (EncodeError, DecodeError)
 
 
 def dumps(data):
-    """Serializes data using Kombu serializer, default format is JSON.
+    """Serializes data using Kombu serializer.
     """
     try:
-        content_type, encoding, data = k_registry.dumps(data)
+        content_type, encoding, data = k_registry.dumps(
+            data, serializer="json")
     except EncodeError as e:
         raise TypeError(e)
     return data

--- a/test_project/test_app/tests.py
+++ b/test_project/test_app/tests.py
@@ -256,7 +256,7 @@ class ResultTest(TransactionTestCase):
                 kwargs={"param": "testing"}, eta=a_date)
             task = TaskResultMeta.objects.all()[0]
             # Fake result as str.
-            result = "\nbob\n"
+            result = '\n"bo""b\n'
             task.result = result
             task.save()
 

--- a/test_project/test_app/tests.py
+++ b/test_project/test_app/tests.py
@@ -248,6 +248,22 @@ class ResultTest(TransactionTestCase):
         task = TaskResultMeta.objects.all()[0]
         self.assertEqual(task.result, result)
 
+    def test_param_result_as_json_str(self):
+        a_date = datetime(2080, 1, 1, tzinfo=utc)
+
+        with self.settings(DJANGO_CELERY_FULLDBRESULT_USE_JSON=True):
+            do_something.apply_async(
+                kwargs={"param": "testing"}, eta=a_date)
+            task = TaskResultMeta.objects.all()[0]
+            # Fake result as str.
+            result = "\nbob\n"
+            task.result = result
+            task.save()
+
+            # Test pickling/unpickling
+            task = TaskResultMeta.objects.all()[0]
+            self.assertEqual(task.result, result)
+
     def test_param_result_as_json(self):
         a_date = datetime(2080, 1, 1, tzinfo=utc)
 


### PR DESCRIPTION
This is a problem we encountered in production and I believe it appeared when we accepted the new serialization pull request.

1. A task returns a string.
2. serialization.dumps will keep the string as is (content type will be application/data). In the past, json.dumps would make sure that the string was a proper json string (it would quote new lines and double quotes, and surround the string between double quotes).
3. when the string is loaded with loads, we tell the serializer that we are expecting application/json, but the string is not json-encoded, so it fails.

I fixed the bug, added a test, and created a command to go through each result and re-encode non-json result. I did not write a migration, because we cannot make any assumption about the database of other users.