### PR TITLE
Run the test suite against Django 1.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django>=1.8
+Django>=1.8,<2.0
 celery>=3.1.15,<4.0
 django_celery>=3.1.17

--- a/test_project/test_project/urls.py
+++ b/test_project/test_project/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.contrib import admin
 
-urlpatterns = patterns('',
+urlpatterns = [
     # Examples:
     # url(r'^$', 'test_project.views.home', name='home'),
     # url(r'^blog/', include('blog.urls')),
 
     url(r'^admin/', include(admin.site.urls)),
-)
+]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,14 @@
 [tox]
-envlist = py27,py34
+envlist = py{27,353,362}-django{18,111}
 skipsdist = false
 
 [testenv]
-deps = -rrequirements.txt
+deps =
+	# Oldest supported version supported by our test suite
+	django18: Django==1.8
+	# Most recent supported version
+	django111: Django==1.11
+	celery>=3.1.15,<4.0
+	django_celery>=3.1.17
 changedir = test_project
 commands = python manage.py test


### PR DESCRIPTION
- Adds a TravisCI build script so the tests are run automatically. You can enable TravisCI builds for free by turning them on at https://travis-ci.org/.
- Makes the test suite compatible with Django 1.11 and ensures the tests are run against it. Python 2.7, 3.5 and 3.6 are tested.